### PR TITLE
Update to webpack step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A clock/weather app for my raspberry pi touchscreen.
 
 - `git clone git@github.com:pifantastic/outside.git && cd outside` – Clone the repo
 - `npm install` – Install dependencies
-- `webpack` – Build static assets
+- `npx webpack` – Build static assets
 - `npm run start` – Start the server
 - Go to http://localhost:3000/
 


### PR DESCRIPTION
Update based on setting up on a fresh machine. Running npx webpack grabs it from the
node_modules/bin, where it will have been installed after npm install. Requires npm v5.2.0 or later.

Feel free to let me know if there's a better/cleaner way :)